### PR TITLE
Fixed Groovy configuration failure due to missing properties

### DIFF
--- a/plugin/src/main/kotlin/io/github/jmatsu/license/VariantAwareOptions.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/VariantAwareOptions.kt
@@ -1,5 +1,6 @@
 package io.github.jmatsu.license
 
+import groovy.lang.Closure
 import io.github.jmatsu.license.dsl.validation.optionalDirectoryProperty
 import java.io.File
 import org.gradle.api.Action
@@ -53,6 +54,24 @@ class VariantAwareOptionsImpl(
 
     override fun getPublicType(): TypeOf<VariantAwareOptions> {
         return typeOf()
+    }
+
+    /**
+     * HACK: For Groovy
+     */
+    fun assembly(action: Closure<AssemblyOptions>) {
+        action.delegate = assembly
+        action.resolveStrategy = Closure.DELEGATE_FIRST
+        action.call()
+    }
+
+    /**
+     * HACK: For Groovy
+     */
+    fun visualization(action: Closure<VisualizationOptions>) {
+        action.delegate = visualization
+        action.resolveStrategy = Closure.DELEGATE_FIRST
+        action.call()
     }
 
     override fun getName(): String = name

--- a/plugin/src/main/kotlin/io/github/jmatsu/license/dsl/validation/DirectoryFile.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/dsl/validation/DirectoryFile.kt
@@ -37,6 +37,8 @@ private fun requireDirectoryFile(value: File?): File? {
         if (!value.isDirectory) {
             error("${value.absolutePath} is not a directory")
         }
+    } else {
+        value.mkdirs()
     }
 
     return value


### PR DESCRIPTION
Close #17 

- Groovy's Closure couldn't resolve thisObject properly so missing property exception had thrown.
- Groovy works with the same syntax of Kotlin (currently)