### PR TITLE
Fixed the html template that include unintended space in the right

### DIFF
--- a/plugin/src/main/kotlin/io/github/jmatsu/license/migration/MigrateLicenseToolsDefinitionTask.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/migration/MigrateLicenseToolsDefinitionTask.kt
@@ -124,8 +124,14 @@ abstract class MigrateLicenseToolsDefinitionTask
 
         val fields = toolsExtension::javaClass.get().fields
 
-        val toolsLicenseFile = fields.first { it.name == "licensesYaml" }.get(toolsExtension) as File
+        var toolsLicenseFile = fields.first { it.name == "licensesYaml" }.get(toolsExtension) as File
         @Suppress("UNCHECKED_CAST") val ignoredGroups = fields.first { it.name == "ignoredGroups" }.get(toolsExtension) as Set<String>
+
+        if (!toolsLicenseFile.exists()) {
+            error("${toolsLicenseFile.absolutePath} is not found. Please specify the filepath in licenseTools extension properly.")
+        }
+
+        logger.warn("The target license tools' file ${toolsLicenseFile.path}")
 
         Executor(
             targetVariant = extension.defaultVariant, // only this value is delivered from my extension

--- a/plugin/src/main/kotlin/io/github/jmatsu/license/presentation/encoder/Html.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/presentation/encoder/Html.kt
@@ -39,7 +39,7 @@ class Html(
         configuration.templateExceptionHandler = TemplateExceptionHandler.RETHROW_HANDLER
 
         val input = mapOf(
-            "title" to "title",
+            "title" to "License List",
             "artifacts" to value
         )
 

--- a/plugin/src/main/resources/templates/license.html.ftl
+++ b/plugin/src/main/resources/templates/license.html.ftl
@@ -9,9 +9,11 @@
         * {
             box-sizing: border-box;
             background-color: #ffffff;
+            padding: 0;
+            margin: 0;
         }
         .container {
-            padding: 2px 2px;
+            padding: 4px 4px;
         }
         .card {
             background-color: #fefefe;
@@ -22,6 +24,7 @@
         p {
             margin: 4px;
             padding: 0;
+            word-break: break-all;
         }
         p.name {
             font-size: 18px;
@@ -34,8 +37,6 @@
         }
         ul {
             list-style-type: none;
-            margin: 0;
-            padding: 0;
         }
         ul.licenses {
             margin: 6px;


### PR DESCRIPTION
nit: throw the error if no file is found when migrating from license tools plugin