### PR TITLE
Use raw content urls for license files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   android:
     docker:
-      - image: circleci/android:api-29
+      - image: circleci/android@sha256:e8a82728a4d2a1b7085f3ada107b492b76aeeefaa7bf739b5addace0a73ba79d
     working_directory: ~/top/example
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:MaxPermSize=256m -XX:+HeapDumpOnOutOfMemoryError" -Dorg.gradle.daemon=false'

--- a/README.md
+++ b/README.md
@@ -32,11 +32,12 @@ For those who have been using `0.3` or lower, version `0.4` has breaking changes
 4. [Extension](#extension)
 5. [Tips](#tips)
     1. [license-tools-plugin migration](#for-license-tools-plugin-users)
-    2. [Exclude specific groups/artifacts](#exclude-specific-groupsartifacts)
-    3. [Add other configurations like WearApp](#additional-configurations-like-wearapp)
-    4. [Custom variant-aware configurations](#custom-variant-aware-configurations)
-    5. [Html template customization](#html-customization)
-    6. [Render Json output](#render-json)
+    2. [Local jar/aar files][#manage-local-files)
+    3. [Exclude specific groups/artifacts](#exclude-specific-groupsartifacts)
+    4. [Add other configurations like WearApp](#additional-configurations-like-wearapp)
+    5. [Custom variant-aware configurations](#custom-variant-aware-configurations)
+    6. [Html template customization](#html-customization)
+    7. [Render Json output](#render-json)
 6. [Known limitation](#limitations)
 7. [Migration](#migration)
     1. [since 0.4](#04-breaking-changes)
@@ -159,6 +160,7 @@ The base format is `Map<Scope, Map<Group, List<ArtifactDefinition>>>`.
       license: # Required
         - "<license key which is defined in license-catalog.yml>"
       skip: "<true|false>" # Optional. Specify true if this artifact is not found in the current dependencies but should be displayed. false by default.
+      # Please use .artifactignore if you would like not to display any artifacts.
     ...
   ...
 ...
@@ -392,6 +394,18 @@ Please move them to the directory where you would like to use for the management
 
 - Each line of `.artifactignore` are the same to `skip` in license-tools-plugin
 - `skip` in `artifact-definition.yml` is the same to `forceGenerate`
+
+## Manage local files
+
+This plugin can manage local files as well. `local-files` is the reserved *group* in `artifact-definition.yml`.
+
+```yaml
+local-files: # equivalent to group
+  - key: "<jar/aar filename (requires the extension)>"
+    ...
+  ...
+...
+```
 
 ### Exclude specific groups/artifacts
 

--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ They are just *interfaces* in pure Kotlin. So you can chose any serialization me
 
 ### 0.7 breaking changes
 
-The generated license URLs have been changed to show the contents correctly. Please update the license files and visualized files.
+The generated license URLs have been changed to show the contents correctly. Please run `mergeLicenseList` and `visualizeLicenseList` tasks to update your license catalog file and visualized file.
 
 ### 0.4 breaking changes
 

--- a/README.md
+++ b/README.md
@@ -496,6 +496,10 @@ They are just *interfaces* in pure Kotlin. So you can chose any serialization me
 
 ## Migration
 
+### 0.7 breaking changes
+
+The generated license URLs have been changed to show the contents correctly. Please update the license files and visualized files.
+
 ### 0.4 breaking changes
 
 Breaking change1 :

--- a/example/app/license-list/license-catalog.yml
+++ b/example/app/license-list/license-catalog.yml
@@ -15,10 +15,10 @@
     url: http://creativecommons.org/licenses/publicdomain
   - key: apache-2.0
     name: Apache License 2.0
-    url: https://github.com/jmatsu/license-list-plugin/blob/master/license-files/apache-2.0.txt
+    url: https://raw.githubusercontent.com/jmatsu/license-list-plugin/master/license-files/apache-2.0.txt
   - key: epl-1.0
     name: Eclipse Public License 1.0
     url: https://opensource.org/licenses/EPL-1.0
   - key: mit
     name: MIT License
-    url: https://github.com/jmatsu/license-list-plugin/blob/master/license-files/mit.txt
+    url: https://raw.githubusercontent.com/jmatsu/license-list-plugin/master/license-files/mit.txt

--- a/example/fixtures/merge/expected-license-catalog.yml
+++ b/example/fixtures/merge/expected-license-catalog.yml
@@ -15,13 +15,13 @@
     url: http://creativecommons.org/licenses/publicdomain
   - key: apache-2.0
     name: Apache License 2.0
-    url: https://github.com/jmatsu/license-list-plugin/blob/master/license-files/apache-2.0.txt
+    url: https://raw.githubusercontent.com/jmatsu/license-list-plugin/master/license-files/apache-2.0.txt
   - key: epl-1.0
     name: Eclipse Public License 1.0
     url: https://opensource.org/licenses/EPL-1.0
   - key: mit
     name: MIT License
-    url: https://github.com/jmatsu/license-list-plugin/blob/master/license-files/mit.txt
+    url: https://raw.githubusercontent.com/jmatsu/license-list-plugin/master/license-files/mit.txt
   - key: new-dummy-license
     name: Dummy License
     url: http://example.com

--- a/example/fixtures/merge/license-catalog.yml
+++ b/example/fixtures/merge/license-catalog.yml
@@ -9,10 +9,10 @@
     url: http://creativecommons.org/licenses/publicdomain
   - key: apache-2.0
     name: Apache License 2.0
-    url: https://github.com/jmatsu/license-list-plugin/blob/master/license-files/apache-2.0.txt
+    url: https://raw.githubusercontent.com/jmatsu/license-list-plugin/master/license-files/apache-2.0.txt
   - key: mit
     name: MIT License
-    url: https://github.com/jmatsu/license-list-plugin/blob/master/license-files/mit.txt
+    url: https://raw.githubusercontent.com/jmatsu/license-list-plugin/master/license-files/mit.txt
   - key: new-dummy-license
     name: Dummy License
     url: http://example.com

--- a/example/fixtures/validate-license-catalog.yml
+++ b/example/fixtures/validate-license-catalog.yml
@@ -15,13 +15,13 @@
     url: http://creativecommons.org/licenses/publicdomain
   - key: apache-2.0
     name: Apache License 2.0
-    url: https://github.com/jmatsu/license-list-plugin/blob/master/license-files/apache-2.0.txt
+    url: https://raw.githubusercontent.com/jmatsu/license-list-plugin/master/license-files/apache-2.0.txt
   - key: epl-1.0
     name: Eclipse Public License 1.0
     url: https://opensource.org/licenses/EPL-1.0
   - key: mit
     name: MIT License
-    url: https://github.com/jmatsu/license-list-plugin/blob/master/license-files/mit.txt
+    url: https://raw.githubusercontent.com/jmatsu/license-list-plugin/master/license-files/mit.txt
   - key: xdefined-license@18
     name: Originally defined License
     url: http://example.com

--- a/plugin/src/main/kotlin/io/github/jmatsu/license/internal/LicenseClassifier.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/internal/LicenseClassifier.kt
@@ -58,7 +58,7 @@ class LicenseClassifier(
 
         abstract class GitHubAPICompatibleLicense : GuessedLicense() {
             override val url: String
-                get() = "https://github.com/jmatsu/license-list-plugin/blob/master/license-files/$key.txt"
+                get() = "https://raw.githubusercontent.com/jmatsu/license-list-plugin/master/license-files/$key.txt"
         }
 
         object AGPL30 : GitHubAPICompatibleLicense() {
@@ -163,7 +163,7 @@ class LicenseClassifier(
         object FacebookSDK : GuessedLicense() {
             override val key: String = PredefinedKey.FACEBOOK_SDK
             override val name: String = "the Facebook Platform License"
-            override val url: String = "https://github.com/facebook/facebook-android-sdk/blob/master/LICENSE.txt"
+            override val url: String = "https://raw.githubusercontent.com/facebook/facebook-android-sdk/master/LICENSE.txt"
         }
 
         object Bcl : GuessedLicense() {

--- a/plugin/src/main/kotlin/io/github/jmatsu/license/presentation/Merger.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/presentation/Merger.kt
@@ -46,12 +46,25 @@ class Merger(
             }.toMap()
 
         val licensesKeysToBeUsed = mergedScopedArtifacts.flatMap { (_, artifacts) -> artifacts.flatMap { it.licenses.map { it.value } } }
-        val mergedLicenses = baseLicenses.reverseMerge(licenseCapture) { it.key }.filter { it.key.value in licensesKeysToBeUsed }
+        val mergedLicenses = baseLicenses.reverseMerge(licenseCapture) { it.key }.filter { it.key.value in licensesKeysToBeUsed }.fixLicenseUrl()
 
         return AssembleeData(
             scopedArtifacts = mergedScopedArtifacts,
             licenses = mergedLicenses
         )
+    }
+
+    /**
+     * v0.7 introduced the breaking changes on license URLs. This hack fixes it.
+     */
+    private fun Iterable<PlainLicense>.fixLicenseUrl(): List<PlainLicense> {
+        return map { license ->
+            if (license.url?.startsWith("https://github.com/jmatsu/license-list-plugin/blob/master/license-files/") == true || license.url == "https://github.com/facebook/facebook-android-sdk/blob/master/LICENSE.txt") {
+                license.copy(url = license.url.replace("github.com", "raw.githubusercontent.com").replace("/blob", ""))
+            } else {
+                license
+            }
+        }
     }
 }
 

--- a/plugin/src/main/kotlin/io/github/jmatsu/license/presentation/Merger.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/presentation/Merger.kt
@@ -59,13 +59,19 @@ class Merger(
      */
     private fun Iterable<PlainLicense>.fixLicenseUrl(): List<PlainLicense> {
         return map { license ->
-            if (license.url?.startsWith("https://github.com/jmatsu/license-list-plugin/blob/master/license-files/") == true || license.url == "https://github.com/facebook/facebook-android-sdk/blob/master/LICENSE.txt") {
+            if (license.url?.isFixTarget == true) {
                 license.copy(url = license.url.replace("github.com", "raw.githubusercontent.com").replace("/blob", ""))
             } else {
                 license
             }
         }
     }
+
+    private val String.isFixTarget: Boolean
+        get() {
+            return startsWith("https://github.com/jmatsu/license-list-plugin/blob/master/license-files/") ||
+                this == "https://github.com/facebook/facebook-android-sdk/blob/master/LICENSE.txt"
+        }
 }
 
 interface MergeStrategy {

--- a/schema/build.gradle.kts
+++ b/schema/build.gradle.kts
@@ -54,9 +54,8 @@ bintray {
         websiteUrl = "https://github.com/jmatsu/license-list-plugin"
         issueTrackerUrl = "https://github.com/jmatsu/license-list-plugin/issues"
         vcsUrl = "https://github.com/jmatsu/license-list-plugin.git"
-        // FIXME out-in after opening a repository
-//        githubRepo = "jmatsu/license-list-plugin"
-//        githubReleaseNotesFile = "CHANGELOG.md"
+        githubRepo = "jmatsu/license-list-plugin"
+        githubReleaseNotesFile = "CHANGELOG.md"
         version(delegateClosureOf<VersionConfig> {
             name = project.version as String
             released = DateTimeFormatter


### PR DESCRIPTION
The previous URLs showed GitHub's web page but it's not good.