### PR TITLE
Fix missing annotations to support Gradle 7

### DIFF
--- a/plugin/src/main/kotlin/io/github/jmatsu/license/AssemblyOptions.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/AssemblyOptions.kt
@@ -12,6 +12,7 @@ import org.gradle.api.Named
 import org.gradle.api.reflect.HasPublicType
 import org.gradle.api.reflect.TypeOf
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.kotlin.dsl.typeOf
 
 interface AssemblyOptions : Named {
@@ -67,11 +68,15 @@ interface AssemblyOptions : Named {
      */
     @get:Input
     var targetConfigurations: Set<String>
+
+    @Input
+    override fun getName(): String
 }
 
 class AssemblyOptionsImpl(private val name: String) : AssemblyOptions, HasPublicType {
     override fun getName(): String = name
 
+    @Internal
     override fun getPublicType(): TypeOf<AssemblyOptions> {
         return typeOf()
     }

--- a/plugin/src/main/kotlin/io/github/jmatsu/license/VariantAwareOptions.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/VariantAwareOptions.kt
@@ -7,10 +7,11 @@ import org.gradle.api.Action
 import org.gradle.api.Named
 import org.gradle.api.reflect.HasPublicType
 import org.gradle.api.reflect.TypeOf
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.kotlin.dsl.typeOf
@@ -20,12 +21,18 @@ interface VariantAwareOptions : Named {
      * @see baseDir
      */
     @Deprecated("the name has been changed. This would be removed in 1.0.0", replaceWith = ReplaceWith("baseDir"))
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:InputDirectory
+    @get:Optional
     var artifactDefinitionDirectory: File?
 
     /**
      * @see baseDir
      */
     @Deprecated("this name was produced by a typo. This will be removed in 1.0.0.", replaceWith = ReplaceWith("baseDir"))
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:InputDirectory
+    @get:Optional
     var dataDir: File?
 
     /**
@@ -33,7 +40,6 @@ interface VariantAwareOptions : Named {
      */
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputDirectory
-    @get:OutputDirectory
     @get:Optional
     var baseDir: File?
 
@@ -46,6 +52,9 @@ interface VariantAwareOptions : Named {
     fun assembly(action: Action<AssemblyOptions>)
 
     fun visualization(action: Action<VisualizationOptions>)
+
+    @Input
+    override fun getName(): String
 }
 
 class VariantAwareOptionsImpl(
@@ -72,6 +81,7 @@ class VariantAwareOptionsImpl(
         action.execute(visualization)
     }
 
+    @Internal
     override fun getPublicType(): TypeOf<VariantAwareOptions> {
         return typeOf()
     }

--- a/plugin/src/main/kotlin/io/github/jmatsu/license/VisualizationOptions.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/VisualizationOptions.kt
@@ -11,6 +11,7 @@ import org.gradle.api.reflect.HasPublicType
 import org.gradle.api.reflect.TypeOf
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
@@ -48,15 +49,19 @@ interface VisualizationOptions : Named {
     /**
      * An output directory of the generated visualized file.
      */
-    @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:OutputDirectory
     @get:Optional
     var outputDir: File?
+
+    @Input
+    override fun getName(): String
 }
 
 class VisualizationOptionsImpl(
     private val name: String
 ) : VisualizationOptions, HasPublicType {
+
+    @Internal
     override fun getPublicType(): TypeOf<VisualizationOptions> {
         return typeOf()
     }


### PR DESCRIPTION
Fix: https://github.com/jmatsu/license-list-plugin/issues/47

Since Gradle 7 Tasks with getters/properties throw errors if they are not properly annotated.

https://docs.gradle.org/7.0.2/userguide/validation_problems.html#missing_annotation

## How to reproduce
1. Update example app to Gradle7
<details>
<summary>diff</summary>
  
```diff
diff --git a/example/app/build.gradle.kts b/example/app/build.gradle.kts
index eacced7..07d3c93 100644
--- a/example/app/build.gradle.kts
+++ b/example/app/build.gradle.kts
@@ -49,9 +49,7 @@ android {
 }
 
 repositories {
-    if (System.getenv("CI") == "true") {
-        mavenLocal()
-    }
+    mavenLocal()
     google()
     jcenter()
 }
diff --git a/example/build.gradle.kts b/example/build.gradle.kts
index 19af07f..ff949b2 100644
--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -2,16 +2,10 @@ buildscript {
     repositories {
         google()
         jcenter()
-        if (System.getenv("CI") == "true") {
-            mavenLocal()
-        } else {
-            maven {
-                url = uri("https://plugins.gradle.org/m2/")
-            }
-        }
+        mavenLocal()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.6.1")
+        classpath("com.android.tools.build:gradle:7.0.0")
         classpath(kotlin("gradle-plugin", version = "1.3.50")) // same to the version that kotlin-dsl uses
         classpath("io.github.jmatsu:license-list-gradle:${rootProject.file("../VERSION").readText().trim()}")
         classpath("com.cookpad.android.licensetools:license-tools-plugin:1.7.0")
diff --git a/example/gradle/wrapper/gradle-wrapper.properties b/example/gradle/wrapper/gradle-wrapper.properties
index 9492014..0f80bbf 100644
--- a/example/gradle/wrapper/gradle-wrapper.properties
+++ b/example/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
```
</details>

2. Execute `./gradlew validateYellowBlueReleaseLicenseList`
3. Build Failed

<details>
<summary>error log</summary>
  
```bash
example ❯ ./gradlew validateYellowBlueReleaseLicenseList                             

FAILURE: Build failed with an exception.

* What went wrong:
Some problems were found with the configuration of task ':app:validateYellowBlueReleaseLicenseList' (type 'ValidateLicenseListTask').
  - Type 'io.github.jmatsu.license.tasks.ValidateLicenseListTask' property 'extension.variants.yellowBlueRelease$0.artifactDefinitionDirectory' is missing an input or output annotation.

    Reason: A property without annotation isn't considered during up-to-date checking.

    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.

    Please refer to https://docs.gradle.org/7.0.2/userguide/validation_problems.html#missing_annotation for more details about this problem.
  - Type 'io.github.jmatsu.license.tasks.ValidateLicenseListTask' property 'extension.variants.yellowBlueRelease$0.ass
embly.name' is missing an input or output annotation.

    Reason: A property without annotation isn't considered during up-to-date checking.

    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.

    Please refer to https://docs.gradle.org/7.0.2/userguide/validation_problems.html#missing_annotation for more details about this problem.
  - Type 'io.github.jmatsu.license.tasks.ValidateLicenseListTask' property 'extension.variants.yellowBlueRelease$0.assembly.publicType' is missing an input or output annotation.

    Reason: A property without annotation isn't considered during up-to-date checking.

    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.

    Please refer to https://docs.gradle.org/7.0.2/userguide/validation_problems.html#missing_annotation for more details about this problem.
  - Type 'io.github.jmatsu.license.tasks.ValidateLicenseListTask' property 'extension.variants.yellowBlueRelease$0.dataDir' is missing an input or output annotation.

    Reason: A property without annotation isn't considered during up-to-date checking.

    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.

    Please refer to https://docs.gradle.org/7.0.2/userguide/validation_problems.html#missing_annotation for more details about this problem.
  - Type 'io.github.jmatsu.license.tasks.ValidateLicenseListTask' property 'extension.variants.yellowBlueRelease$0.name' is missing an input or output annotation.

    Reason: A property without annotation isn't considered during up-to-date checking.

		Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.

    Please refer to https://docs.gradle.org/7.0.2/userguide/validation_problems.html#missing_annotation for more details about this problem.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 760ms
```
</details>