### PR TITLE
Support Gradle 8 and AGP 8.13

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
 }

--- a/buildSrc/src/main/java/shared/Version.kt
+++ b/buildSrc/src/main/java/shared/Version.kt
@@ -1,17 +1,17 @@
 package shared
 
 object Version {
-    const val kotlin = "1.3.71"
-    const val kotlinSerialization = "0.20.0"
-    const val kaml = "0.17.0"
+    const val kotlin = "2.2.21"
+    const val kotlinSerialization = "1.9.0"
+    const val kaml = "0.102.0"
     const val freemaker = "2.3.30"
     const val snakeyaml = "1.26"
 
-    const val kotlinter = "2.3.2"
+    const val kotlinter = "5.2.0"
     const val bintray = "1.8.4"
-    const val agp = "3.6.1"
+    const val agp = "8.13.1"
 
-    const val junit5 = "5.6.1"
-    const val junitPlatformLauncher = "1.6.1" // requires this to run tests from IntelliJ
-    const val mockk = "1.9.3"
+    const val junit5 = "5.14.0"
+    const val junitPlatformLauncher = "1.14.1" // requires this to run tests from IntelliJ
+    const val mockk = "1.14.6"
 }

--- a/example/settings.gradle.kts
+++ b/example/settings.gradle.kts
@@ -2,8 +2,7 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         google()
-        jcenter()
-        maven(url = "https://kotlin.bintray.com/kotlinx")
+        mavenCentral()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri Sep 19 22:52:42 JST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
     // release stuff
     `maven-publish`
-    id("com.gradle.plugin-publish") version "0.11.0"
+    id("com.gradle.plugin-publish") version "2.0.0"
 }
 
 repositories {
@@ -50,7 +50,8 @@ dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime:${Version.kotlinSerialization}")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:${Version.kotlinSerialization}")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:${Version.kotlinSerialization}")
     implementation("com.charleskorn.kaml:kaml:${Version.kaml}")
 
     implementation("org.freemarker:freemarker:${Version.freemaker}")
@@ -60,7 +61,6 @@ dependencies {
     testImplementation("com.android.tools.build:gradle:${Version.agp}")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test")
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
     testImplementation("io.mockk:mockk:${Version.mockk}")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api")
@@ -74,11 +74,14 @@ dependencies {
 }
 
 gradlePlugin {
+    website = Definition.webUrl
+    vcsUrl = Definition.vcsUrl
     val `license-list-gradle` by plugins.creating {
         id = Definition.pluginId
         implementationClass = "io.github.jmatsu.license.LicenseListPlugin"
         displayName = Definition.pluginDisplayName
         description = Definition.pluginDescription
+        tags = listOf("android", "gradle")
     }
 }
 
@@ -92,26 +95,15 @@ val check by tasks.getting(Task::class) {
 }
 
 kotlinter {
-    ignoreFailures = false
+    ignoreLintFailures = false
     reporters = arrayOf("checkstyle", "html")
-    experimentalRules = false
-    fileBatchSize = 30
+//    experimentalRules = false
+//    fileBatchSize = 30
 }
 
 java {
     withJavadocJar()
     withSourcesJar()
-}
-
-pluginBundle {
-    website = Definition.webUrl
-    vcsUrl = Definition.vcsUrl
-    tags = listOf("android", "gradle")
-
-    mavenCoordinates {
-        groupId = project.group as String
-        artifactId = Definition.pluginName
-    }
 }
 
 afterEvaluate {

--- a/plugin/src/main/kotlin/io/github/jmatsu/license/migration/LibraryInfo.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/migration/LibraryInfo.kt
@@ -1,17 +1,17 @@
 package io.github.jmatsu.license.migration
 
-import kotlinx.serialization.CompositeDecoder
-import kotlinx.serialization.Decoder
-import kotlinx.serialization.Encoder
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SerialDescriptor
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.Serializer
-import kotlinx.serialization.builtins.list
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
-@Serializable
+@Serializable(LibraryInfo.Companion::class)
 data class LibraryInfo(
     val artifact: String,
     val name: String = "",
@@ -27,9 +27,8 @@ data class LibraryInfo(
     val copyrightHolders: List<String> = emptyList(),
     val author: String = ""
 ) {
-    @Serializer(forClass = LibraryInfo::class)
     companion object : KSerializer<LibraryInfo> {
-        override val descriptor: SerialDescriptor = SerialDescriptor("LibraryInfo") {
+        override val descriptor: SerialDescriptor = buildClassSerialDescriptor("LibraryInfo") {
             element("artifact", String.serializer().descriptor)
             element("name", String.serializer().descriptor, isOptional = true)
             element("filename", String.serializer().descriptor, isOptional = true)
@@ -40,8 +39,8 @@ data class LibraryInfo(
             element("url", String.serializer().descriptor, isOptional = true)
             element("skip", Boolean.serializer().descriptor, isOptional = true)
             element("forceGenerate", Boolean.serializer().descriptor, isOptional = true)
-            element("authors", String.serializer().list.descriptor, isOptional = true)
-            element("copyrightHolders", String.serializer().list.descriptor, isOptional = true)
+            element("authors", ListSerializer(String.serializer()).descriptor, isOptional = true)
+            element("copyrightHolders", ListSerializer(String.serializer()).descriptor, isOptional = true)
             element("author", String.serializer().descriptor, isOptional = true)
         }
 
@@ -63,7 +62,7 @@ data class LibraryInfo(
             decoder.beginStructure(descriptor).apply {
                 loop@ while (true) {
                     when (val index = decodeElementIndex(descriptor)) {
-                        CompositeDecoder.READ_DONE -> break@loop
+                        CompositeDecoder.DECODE_DONE -> break@loop
                         0 -> artifact = decodeStringElement(descriptor, index)
                         1 -> name = decodeStringElement(descriptor, index)
                         2 -> filename = decodeStringElement(descriptor, index)
@@ -74,8 +73,8 @@ data class LibraryInfo(
                         7 -> url = decodeStringElement(descriptor, index)
                         8 -> skip = decodeBooleanElement(descriptor, index)
                         9 -> forceGenerate = decodeBooleanElement(descriptor, index)
-                        10 -> authors = decodeSerializableElement(descriptor, index, String.serializer().list)
-                        11 -> copyrightHolders = decodeSerializableElement(descriptor, index, String.serializer().list)
+                        10 -> authors = decodeSerializableElement(descriptor, index, ListSerializer(String.serializer()))
+                        11 -> copyrightHolders = decodeSerializableElement(descriptor, index, ListSerializer(String.serializer()))
                         12 -> author = decodeStringElement(descriptor, index)
                         else -> throw SerializationException("Unknown index $index")
                     }

--- a/plugin/src/main/kotlin/io/github/jmatsu/license/poko/ArtifactDefinition.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/poko/ArtifactDefinition.kt
@@ -1,17 +1,17 @@
 package io.github.jmatsu.license.poko
 
-import kotlinx.serialization.Decoder
-import kotlinx.serialization.Encoder
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Required
-import kotlinx.serialization.SerialDescriptor
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.Transient
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 private typealias PokoArtifactDefinition = io.github.jmatsu.license.schema.ArtifactDefinition<LicenseKey>
 
-@Serializable
+@Serializable(ArtifactDefinition.Companion::class)
 data class ArtifactDefinition(
     override val key: String,
     override val displayName: String,
@@ -42,16 +42,13 @@ data class ArtifactDefinition(
     /**
      * The serializer that deserializes keep properly and serializes *keep* attribute iff it's true
      */
-    @Serializer(forClass = ArtifactDefinition::class)
     companion object : KSerializer<ArtifactDefinition> {
         private val coreSerializer: KSerializer<OptionalKeep>
             get() = OptionalKeep.serializer()
 
         override val descriptor: SerialDescriptor by lazy {
             // Rename
-            object : SerialDescriptor by coreSerializer.descriptor {
-                override val serialName: String = "ArtifactDefinition"
-            }
+            buildClassSerialDescriptor("ArtifactDefinition")
         }
 
         override fun deserialize(decoder: Decoder): ArtifactDefinition {

--- a/plugin/src/main/kotlin/io/github/jmatsu/license/poko/ArtifactIgnore.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/poko/ArtifactIgnore.kt
@@ -1,24 +1,22 @@
+@file:UseContextualSerialization
 package io.github.jmatsu.license.poko
 
-import io.github.jmatsu.license.schema.ArtifactIgnore
-import kotlinx.serialization.ContextualSerialization
-import kotlinx.serialization.Decoder
-import kotlinx.serialization.Encoder
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.PrimitiveKind
-import kotlinx.serialization.SerialDescriptor
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.Serializer
+import kotlinx.serialization.UseContextualSerialization
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
-@Serializable
+@Serializable(ArtifactIgnore.Companion::class)
 data class ArtifactIgnore(
-    // To suppress a serializer not found error
-    @ContextualSerialization override val regex: Regex
-) : ArtifactIgnore {
-    @Serializer(forClass = ArtifactIgnore::class)
+    override val regex: Regex
+) : io.github.jmatsu.license.schema.ArtifactIgnore {
     companion object : KSerializer<ArtifactIgnore> {
         override val descriptor: SerialDescriptor =
-            SerialDescriptor("ArtifactIgnore", PrimitiveKind.STRING)
+            PrimitiveSerialDescriptor("ArtifactIgnore", PrimitiveKind.STRING)
 
         override fun deserialize(decoder: Decoder): ArtifactIgnore {
             return ArtifactIgnore(regex = Regex(decoder.decodeString()))

--- a/plugin/src/main/kotlin/io/github/jmatsu/license/poko/License.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/poko/License.kt
@@ -1,25 +1,24 @@
 package io.github.jmatsu.license.poko
 
-import kotlinx.serialization.Decoder
-import kotlinx.serialization.Encoder
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.PrimitiveKind
 import kotlinx.serialization.Required
-import kotlinx.serialization.SerialDescriptor
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.Serializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
 sealed class License
 
-@Serializable
+@Serializable(LicenseKey.Companion::class)
 data class LicenseKey(
     override val value: String
 ) : License(), io.github.jmatsu.license.schema.LicenseKey {
     // TODO Make LicenseKey inline class if Serialization supports it, then I can remove this
-    @Serializer(forClass = LicenseKey::class)
     companion object : KSerializer<LicenseKey> {
         override val descriptor: SerialDescriptor =
-            SerialDescriptor("LicenseKey", PrimitiveKind.STRING)
+            PrimitiveSerialDescriptor("LicenseKey", PrimitiveKind.STRING)
 
         override fun deserialize(decoder: Decoder): LicenseKey {
             return LicenseKey(decoder.decodeString())

--- a/plugin/src/main/kotlin/io/github/jmatsu/license/poko/Scope.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/poko/Scope.kt
@@ -1,23 +1,22 @@
 package io.github.jmatsu.license.poko
 
-import kotlinx.serialization.Decoder
-import kotlinx.serialization.Encoder
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.PrimitiveKind
-import kotlinx.serialization.SerialDescriptor
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.Serializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
-@Serializable
+@Serializable(Scope.Companion::class)
 data class Scope(
     override val name: String
 ) : io.github.jmatsu.license.schema.Scope {
 
     // TODO Make Scope inline class if Serialization supports it, then I can remove this
-    @Serializer(forClass = Scope::class)
     companion object : KSerializer<Scope> {
         override val descriptor: SerialDescriptor =
-            SerialDescriptor("Scope", PrimitiveKind.STRING)
+            PrimitiveSerialDescriptor("Scope", PrimitiveKind.STRING)
 
         override fun deserialize(decoder: Decoder): Scope {
             return Scope(decoder.decodeString())

--- a/plugin/src/main/kotlin/io/github/jmatsu/license/presentation/Assembler.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/presentation/Assembler.kt
@@ -6,8 +6,8 @@ import io.github.jmatsu.license.poko.ArtifactDefinition
 import io.github.jmatsu.license.poko.PlainLicense
 import io.github.jmatsu.license.poko.Scope
 import kotlinx.serialization.StringFormat
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.MapSerializer
-import kotlinx.serialization.builtins.list
 import kotlinx.serialization.builtins.serializer
 
 class Assembler(
@@ -24,16 +24,16 @@ class Assembler(
 
         return when (style) {
             Style.Flatten -> {
-                val serializer = ArtifactDefinition.serializer().list
-                format.stringify(serializer, scopedArtifacts.values.flatten().sorted())
+                val serializer = ListSerializer(ArtifactDefinition.serializer())
+                format.encodeToString(serializer, scopedArtifacts.values.flatten().sorted())
             }
             Style.StructuredWithoutScope -> {
-                val serializer = MapSerializer(String.serializer(), ArtifactDefinition.serializer().list)
-                format.stringify(serializer, scopedArtifacts.values.flatten().collectToMapByArtifactGroup())
+                val serializer = MapSerializer(String.serializer(), ListSerializer(ArtifactDefinition.serializer()))
+                format.encodeToString(serializer, scopedArtifacts.values.flatten().collectToMapByArtifactGroup())
             }
             Style.StructuredWithScope -> {
-                val serializer = MapSerializer(Scope.serializer(), MapSerializer(String.serializer(), ArtifactDefinition.serializer().list))
-                format.stringify(serializer, scopedArtifacts.mapValues { (_, artifacts) -> artifacts.collectToMapByArtifactGroup() })
+                val serializer = MapSerializer(Scope.serializer(), MapSerializer(String.serializer(), ListSerializer(ArtifactDefinition.serializer())))
+                format.encodeToString(serializer, scopedArtifacts.mapValues { (_, artifacts) -> artifacts.collectToMapByArtifactGroup() })
             }
         }
     }
@@ -45,7 +45,7 @@ class Assembler(
             LicenseListPlugin.logger?.info(it.key.toString())
         }
 
-        return format.stringify(PlainLicense.serializer().list, licenses)
+        return format.encodeToString(ListSerializer(PlainLicense.serializer()), licenses)
     }
 }
 

--- a/plugin/src/main/kotlin/io/github/jmatsu/license/presentation/Convention.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/presentation/Convention.kt
@@ -3,15 +3,14 @@ package io.github.jmatsu.license.presentation
 import com.charleskorn.kaml.YamlConfiguration
 import io.github.jmatsu.license.presentation.encoder.Html
 import io.github.jmatsu.license.presentation.encoder.HtmlConfiguration
-import kotlinx.serialization.json.JsonConfiguration
-import kotlinx.serialization.modules.EmptyModule
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.EmptySerializersModule
 
 object Convention {
     object Yaml {
         val Assembly = io.github.jmatsu.license.presentation.encoder.Yaml(
-            context = EmptyModule,
+            serializersModule = EmptySerializersModule(),
             kaml = com.charleskorn.kaml.Yaml(
-                context = EmptyModule,
                 configuration = YamlConfiguration(
                     strictMode = false
                 )
@@ -20,26 +19,21 @@ object Convention {
     }
 
     object Json {
-        val Assembly = kotlinx.serialization.json.Json(
-            context = EmptyModule,
-            configuration = JsonConfiguration.Stable.copy(
-                ignoreUnknownKeys = true
-            )
-        )
-        val Visualization = kotlinx.serialization.json.Json(
-            context = EmptyModule,
-            configuration = JsonConfiguration.Stable.copy(
-                ignoreUnknownKeys = true,
-                unquotedPrint = false,
-                prettyPrint = false
-            )
-        )
+        val Assembly = Json {
+            serializersModule = EmptySerializersModule()
+            ignoreUnknownKeys = true
+        }
+        val Visualization = Json {
+            serializersModule = EmptySerializersModule()
+            ignoreUnknownKeys = true
+            prettyPrint = false
+        }
     }
 
     object Html {
         @Suppress("FunctionName")
         fun Visualization(htmlConfiguration: HtmlConfiguration) = Html(
-            context = EmptyModule,
+            serializersModule = EmptySerializersModule(),
             htmlConfiguration = htmlConfiguration
         )
     }

--- a/plugin/src/main/kotlin/io/github/jmatsu/license/presentation/Diff.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/presentation/Diff.kt
@@ -1,6 +1,5 @@
 package io.github.jmatsu.license.presentation
 
-import com.google.common.collect.Sets
 import io.github.jmatsu.license.poko.ArtifactDefinition
 import io.github.jmatsu.license.poko.LicenseKey
 
@@ -19,8 +18,8 @@ object Diff {
 
         val keepKeys = base.mapNotNull { a -> a.key.takeIf { a.keep } }.toSet()
 
-        val added = Sets.difference(newerKeys, baseKeys)
-        val removed = Sets.difference(baseKeys, newerKeys).filterNot { keepKeys.contains(it) }.toSet()
+        val added = newerKeys - baseKeys
+        val removed = (baseKeys - newerKeys).filterNot { keepKeys.contains(it) }.toSet()
 
         return DiffResult(
             missingKeys = added,
@@ -33,8 +32,8 @@ object Diff {
         val baseKeys = base.map { it.value }.toSet()
         val newerKeys = newer.map { it.value }.toSet()
 
-        val added = Sets.difference(newerKeys, baseKeys)
-        val removed = Sets.difference(baseKeys, newerKeys)
+        val added = newerKeys - baseKeys
+        val removed = baseKeys - newerKeys
 
         return DiffResult(
             missingKeys = added,

--- a/plugin/src/main/kotlin/io/github/jmatsu/license/presentation/Disassembler.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/presentation/Disassembler.kt
@@ -4,9 +4,10 @@ import io.github.jmatsu.license.poko.ArtifactDefinition
 import io.github.jmatsu.license.poko.PlainLicense
 import io.github.jmatsu.license.poko.Scope
 import kotlinx.serialization.StringFormat
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.MapSerializer
-import kotlinx.serialization.builtins.list
 import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.decodeFromString
 
 class Disassembler(
     private val style: Assembler.Style,
@@ -16,20 +17,20 @@ class Disassembler(
         return when (style) {
             Assembler.Style.Flatten -> {
                 mapOf(
-                    Scope.StubScope to format.parse(ArtifactDefinition.serializer().list, text)
+                    Scope.StubScope to format.decodeFromString(ListSerializer(ArtifactDefinition.serializer()), text)
                 )
             }
             Assembler.Style.StructuredWithoutScope -> {
-                val serializer = MapSerializer(String.serializer(), ArtifactDefinition.serializer().list)
+                val serializer = MapSerializer(String.serializer(), ListSerializer(ArtifactDefinition.serializer()))
                 mapOf(
-                    Scope.StubScope to format.parse(serializer, text).flatMap { (group, artifacts) ->
+                    Scope.StubScope to format.decodeFromString(serializer, text).flatMap { (group, artifacts) ->
                         artifacts.map { it.copy(key = "$group:${it.key}") }
                     }
                 )
             }
             Assembler.Style.StructuredWithScope -> {
-                val serializer = MapSerializer(Scope.serializer(), MapSerializer(String.serializer(), ArtifactDefinition.serializer().list))
-                format.parse(serializer, text)
+                val serializer = MapSerializer(Scope.serializer(), MapSerializer(String.serializer(), ListSerializer(ArtifactDefinition.serializer())))
+                format.decodeFromString(serializer, text)
                     .mapValues { (_, m) ->
                         m.flatMap { (group, artifacts) ->
                             artifacts.map { it.copy(key = "$group:${it.key}") }
@@ -40,7 +41,7 @@ class Disassembler(
     }
 
     fun disassemblePlainLicenses(text: String): List<PlainLicense> {
-        val serializer = PlainLicense.serializer().list
-        return format.parse(serializer, text)
+        val serializer = ListSerializer(PlainLicense.serializer())
+        return format.decodeFromString(serializer, text)
     }
 }

--- a/plugin/src/main/kotlin/io/github/jmatsu/license/presentation/Visualizer.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/presentation/Visualizer.kt
@@ -2,12 +2,12 @@ package io.github.jmatsu.license.presentation
 
 import io.github.jmatsu.license.poko.DisplayArtifact
 import kotlinx.serialization.StringFormat
-import kotlinx.serialization.builtins.list
+import kotlinx.serialization.builtins.ListSerializer
 
 class Visualizer(
     private val displayArtifacts: List<DisplayArtifact>
 ) {
     fun visualizeArtifacts(format: StringFormat): String {
-        return format.stringify(DisplayArtifact.serializer().list, displayArtifacts)
+        return format.encodeToString(ListSerializer(DisplayArtifact.serializer()), displayArtifacts)
     }
 }

--- a/plugin/src/main/kotlin/io/github/jmatsu/license/presentation/encoder/Html.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/presentation/encoder/Html.kt
@@ -8,21 +8,21 @@ import java.util.Locale
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.StringFormat
-import kotlinx.serialization.modules.EmptyModule
-import kotlinx.serialization.modules.SerialModule
+import kotlinx.serialization.modules.EmptySerializersModule
+import kotlinx.serialization.modules.SerializersModule
 
 /**
  * Not a proper string format of kotlin serialization. This is just a wrapper class to unify types.
  */
 class Html(
-    override val context: SerialModule = EmptyModule,
+    override val serializersModule: SerializersModule = EmptySerializersModule(),
     private val htmlConfiguration: HtmlConfiguration
 ) : StringFormat {
-    override fun <T> parse(deserializer: DeserializationStrategy<T>, string: String): T {
+    override fun <T> decodeFromString(deserializer: DeserializationStrategy<T>, string: String): T {
         error("does not support")
     }
 
-    override fun <T> stringify(serializer: SerializationStrategy<T>, value: T): String {
+    override fun <T> encodeToString(serializer: SerializationStrategy<T>, value: T): String {
         @Suppress("UNCHECKED_CAST")
         value as List<DisplayArtifact>
 

--- a/plugin/src/main/kotlin/io/github/jmatsu/license/presentation/encoder/Yaml.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/presentation/encoder/Yaml.kt
@@ -5,20 +5,20 @@ import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerialFormat
 import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.StringFormat
-import kotlinx.serialization.modules.EmptyModule
-import kotlinx.serialization.modules.SerialModule
+import kotlinx.serialization.modules.EmptySerializersModule
+import kotlinx.serialization.modules.SerializersModule
 import org.yaml.snakeyaml.DumperOptions
 import org.yaml.snakeyaml.Yaml as SnakeYaml
 
 class Yaml(
-    override val context: SerialModule = EmptyModule,
+    override val serializersModule: SerializersModule = EmptySerializersModule(),
     private val kaml: Kaml
 ) : SerialFormat by kaml, StringFormat {
-    override fun <T> parse(deserializer: DeserializationStrategy<T>, string: String): T =
-        kaml.parse(deserializer, string)
+    override fun <T> decodeFromString(deserializer: DeserializationStrategy<T>, string: String): T =
+        kaml.decodeFromString(deserializer, string)
 
-    override fun <T> stringify(serializer: SerializationStrategy<T>, value: T): String {
-        val output = kaml.stringify(serializer, value)
+    override fun <T> encodeToString(serializer: SerializationStrategy<T>, value: T): String {
+        val output = kaml.encodeToString(serializer, value)
 
         // TODO expose these options through extension
         val snake = SnakeYaml(DumperOptions().apply {

--- a/plugin/src/main/kotlin/io/github/jmatsu/license/tasks/InitLicenseListTask.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/tasks/InitLicenseListTask.kt
@@ -1,7 +1,6 @@
 package io.github.jmatsu.license.tasks
 
 import com.android.build.gradle.api.ApplicationVariant
-import com.google.common.annotations.VisibleForTesting
 import io.github.jmatsu.license.LicenseListExtension
 import io.github.jmatsu.license.internal.ArtifactIgnoreParser
 import io.github.jmatsu.license.internal.ArtifactManagement
@@ -14,6 +13,7 @@ import io.github.jmatsu.license.tasks.internal.VariantAwareTask
 import javax.inject.Inject
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
+import org.jetbrains.annotations.VisibleForTesting
 
 abstract class InitLicenseListTask
 @Inject constructor(

--- a/plugin/src/main/kotlin/io/github/jmatsu/license/tasks/InspectLicenseListTask.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/tasks/InspectLicenseListTask.kt
@@ -1,7 +1,6 @@
 package io.github.jmatsu.license.tasks
 
 import com.android.build.gradle.api.ApplicationVariant
-import com.google.common.annotations.VisibleForTesting
 import io.github.jmatsu.license.LicenseListExtension
 import io.github.jmatsu.license.presentation.ArtifactInspector
 import io.github.jmatsu.license.presentation.Disassembler
@@ -13,6 +12,7 @@ import javax.inject.Inject
 import org.gradle.api.Project
 import org.gradle.api.logging.Logger
 import org.gradle.api.tasks.TaskAction
+import org.jetbrains.annotations.VisibleForTesting
 
 abstract class InspectLicenseListTask
 @Inject constructor(

--- a/plugin/src/main/kotlin/io/github/jmatsu/license/tasks/MergeLicenseListTask.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/tasks/MergeLicenseListTask.kt
@@ -1,7 +1,6 @@
 package io.github.jmatsu.license.tasks
 
 import com.android.build.gradle.api.ApplicationVariant
-import com.google.common.annotations.VisibleForTesting
 import io.github.jmatsu.license.LicenseListExtension
 import io.github.jmatsu.license.internal.ArtifactIgnoreParser
 import io.github.jmatsu.license.internal.ArtifactManagement
@@ -14,6 +13,7 @@ import io.github.jmatsu.license.tasks.internal.VariantAwareTask
 import javax.inject.Inject
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
+import org.jetbrains.annotations.VisibleForTesting
 
 abstract class MergeLicenseListTask
 @Inject constructor(

--- a/plugin/src/main/kotlin/io/github/jmatsu/license/tasks/ValidateLicenseListTask.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/tasks/ValidateLicenseListTask.kt
@@ -1,7 +1,6 @@
 package io.github.jmatsu.license.tasks
 
 import com.android.build.gradle.api.ApplicationVariant
-import com.google.common.annotations.VisibleForTesting
 import io.github.jmatsu.license.LicenseListExtension
 import io.github.jmatsu.license.internal.ArtifactIgnoreParser
 import io.github.jmatsu.license.internal.ArtifactManagement
@@ -16,6 +15,7 @@ import javax.inject.Inject
 import org.gradle.api.Project
 import org.gradle.api.logging.Logger
 import org.gradle.api.tasks.TaskAction
+import org.jetbrains.annotations.VisibleForTesting
 
 abstract class ValidateLicenseListTask
 @Inject constructor(

--- a/plugin/src/main/kotlin/io/github/jmatsu/license/tasks/VisualizeLicenseListTask.kt
+++ b/plugin/src/main/kotlin/io/github/jmatsu/license/tasks/VisualizeLicenseListTask.kt
@@ -1,7 +1,6 @@
 package io.github.jmatsu.license.tasks
 
 import com.android.build.gradle.api.ApplicationVariant
-import com.google.common.annotations.VisibleForTesting
 import freemarker.template.Version
 import io.github.jmatsu.license.LicenseListExtension
 import io.github.jmatsu.license.dsl.HtmlFormat
@@ -18,6 +17,7 @@ import javax.inject.Inject
 import kotlinx.serialization.StringFormat
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
+import org.jetbrains.annotations.VisibleForTesting
 
 abstract class VisualizeLicenseListTask
 @Inject constructor(

--- a/plugin/src/test/kotlin/io/github/jmatsu/license/AssemblyOptionsImplTest.kt
+++ b/plugin/src/test/kotlin/io/github/jmatsu/license/AssemblyOptionsImplTest.kt
@@ -6,15 +6,15 @@ import io.github.jmatsu.license.internal.ArtifactManagement
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import org.junit.Before
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import kotlin.test.BeforeTest
 
 class AssemblyOptionsImplTest {
 
     lateinit var options: AssemblyOptions
 
-    @Before
+    @BeforeTest
     fun setup() {
         options = AssemblyOptionsImpl(
             name = "default"

--- a/plugin/src/test/kotlin/io/github/jmatsu/license/VisualizationOptionsImplTest.kt
+++ b/plugin/src/test/kotlin/io/github/jmatsu/license/VisualizationOptionsImplTest.kt
@@ -4,15 +4,15 @@ import io.github.jmatsu.license.dsl.HtmlFormat
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
-import org.junit.Before
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import kotlin.test.BeforeTest
 
 class VisualizationOptionsImplTest {
 
     lateinit var options: VisualizationOptions
 
-    @Before
+    @BeforeTest
     fun setup() {
         options = VisualizationOptionsImpl(
             name = "default"

--- a/plugin/src/test/kotlin/io/github/jmatsu/license/ext/SetTest.kt
+++ b/plugin/src/test/kotlin/io/github/jmatsu/license/ext/SetTest.kt
@@ -1,8 +1,8 @@
 package io.github.jmatsu.license.ext
 
 import kotlin.test.expect
-import org.junit.Test
 import org.junit.jupiter.api.assertThrows
+import kotlin.test.Test
 
 class SetTest {
 

--- a/plugin/src/test/kotlin/io/github/jmatsu/license/poko/ArtifactDefinitionTest.kt
+++ b/plugin/src/test/kotlin/io/github/jmatsu/license/poko/ArtifactDefinitionTest.kt
@@ -2,34 +2,30 @@ package io.github.jmatsu.license.poko
 
 import io.github.jmatsu.license.Factory.provideArtifact
 import java.util.stream.Stream
-import kotlin.test.BeforeTest
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.test.expect
-import kotlinx.serialization.ImplicitReflectionSerializer
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonConfiguration
-import org.junit.Test
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
+import kotlin.test.Test
 
 class ArtifactDefinitionTest {
     lateinit var json: Json
 
     @BeforeEach
-    @BeforeTest
     fun setup() {
-        json = Json(configuration = JsonConfiguration.Stable)
+        json = Json {  }
     }
 
     @Test
     fun `serialize ArtifactDefinition with keep`() {
         val artifactDefinition = provideArtifact(key = "key").copy(keep = true)
 
-        val serialized = json.stringify(ArtifactDefinition.serializer(), artifactDefinition)
+        val serialized = json.encodeToString(ArtifactDefinition.serializer(), artifactDefinition)
 
         assertTrue(serialized.contains(""""keep":true"""))
     }
@@ -38,12 +34,12 @@ class ArtifactDefinitionTest {
     fun `serialize ArtifactDefinition without keep`() {
         val artifactDefinition = provideArtifact(key = "key")
 
-        val serialized = json.stringify(ArtifactDefinition.serializer(), artifactDefinition)
+        val serialized = json.encodeToString(ArtifactDefinition.serializer(), artifactDefinition)
 
         assertFalse(serialized.contains(""""keep":"""))
     }
 
-    @ImplicitReflectionSerializer
+//    @ImplicitReflectionSerializer
     @ValueSource(
         booleans = [true, false]
     )
@@ -69,7 +65,7 @@ class ArtifactDefinitionTest {
         """.trimIndent()
 
         expect(artifactDefinition) {
-            json.parse(ArtifactDefinition.serializer(), jsonString)
+            json.decodeFromString(ArtifactDefinition.serializer(), jsonString)
         }
     }
 
@@ -93,13 +89,13 @@ class ArtifactDefinitionTest {
     @MethodSource("provideArtifactDefinitions")
     @ParameterizedTest
     fun `serialize and deserialize ArtifactDefinition`(artifactDefinition: ArtifactDefinition) {
-        val json = Json(configuration = JsonConfiguration.Stable)
+        val json = Json { }
 
-        val serialized = json.stringify(ArtifactDefinition.serializer(), artifactDefinition)
+        val serialized = json.encodeToString(ArtifactDefinition.serializer(), artifactDefinition)
 
         // string comparision would be unstable because it depends on the order of the properties.
         expect(artifactDefinition) {
-            json.parse(ArtifactDefinition.serializer(), serialized)
+            json.decodeFromString(ArtifactDefinition.serializer(), serialized)
         }
     }
 

--- a/plugin/src/test/kotlin/io/github/jmatsu/license/poko/LicenseTest.kt
+++ b/plugin/src/test/kotlin/io/github/jmatsu/license/poko/LicenseTest.kt
@@ -2,16 +2,15 @@ package io.github.jmatsu.license.poko
 
 import kotlin.test.expect
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonConfiguration
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
 
 class LicenseTest {
     lateinit var json: Json
 
-    @Before
+    @BeforeTest
     fun setup() {
-        json = Json(configuration = JsonConfiguration.Stable)
+        json = Json { }
     }
 
     @Test
@@ -21,7 +20,7 @@ class LicenseTest {
         )
 
         expect("\"license\"") {
-            json.stringify(LicenseKey.serializer(), license)
+            json.encodeToString(LicenseKey.serializer(), license)
         }
     }
 
@@ -32,7 +31,7 @@ class LicenseTest {
         )
 
         expect(expected) {
-            json.parse(LicenseKey.serializer(), "\"license\"")
+            json.decodeFromString(LicenseKey.serializer(), "\"license\"")
         }
     }
 
@@ -45,7 +44,7 @@ class LicenseTest {
         )
 
         expect("""{"key":"key","name":"name","url":"url"}""") {
-            json.stringify(PlainLicense.serializer(), license)
+            json.encodeToString(PlainLicense.serializer(), license)
         }
     }
 
@@ -58,7 +57,7 @@ class LicenseTest {
         )
 
         expect(expected) {
-            json.parse(PlainLicense.serializer(), """{ "name": "name", "url": "url", "key": "key" }""")
+            json.decodeFromString(PlainLicense.serializer(), """{ "name": "name", "url": "url", "key": "key" }""")
         }
     }
 }

--- a/plugin/src/test/kotlin/io/github/jmatsu/license/poko/ScopeTest.kt
+++ b/plugin/src/test/kotlin/io/github/jmatsu/license/poko/ScopeTest.kt
@@ -2,16 +2,15 @@ package io.github.jmatsu.license.poko
 
 import kotlin.test.expect
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonConfiguration
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
 
 class ScopeTest {
     lateinit var json: Json
 
-    @Before
+    @BeforeTest
     fun setup() {
-        json = Json(configuration = JsonConfiguration.Stable)
+        json = Json { }
     }
 
     @Test
@@ -21,7 +20,7 @@ class ScopeTest {
         )
 
         expect("\"scope\"") {
-            json.stringify(Scope.serializer(), scope)
+            json.encodeToString(Scope.serializer(), scope)
         }
     }
 
@@ -32,7 +31,7 @@ class ScopeTest {
         )
 
         expect(expected) {
-            json.parse(Scope.serializer(), "\"scope\"")
+            json.decodeFromString(Scope.serializer(), "\"scope\"")
         }
     }
 }

--- a/plugin/src/test/kotlin/io/github/jmatsu/license/presentation/VisualizerTest.kt
+++ b/plugin/src/test/kotlin/io/github/jmatsu/license/presentation/VisualizerTest.kt
@@ -20,14 +20,14 @@ class VisualizerTest {
         )
 
         val format: StringFormat = mockk {
-            every { stringify<List<DisplayArtifact>>(any(), any()) } returns expectedText
+            every { encodeToString<List<DisplayArtifact>>(any(), any()) } returns expectedText
         }
 
         val actualText = visualizer.visualizeArtifacts(format)
 
         verify {
             // serializer will be returned new instances for every calls
-            format.stringify(any(), displayArtifacts)
+            format.encodeToString(any(), displayArtifacts)
         }
 
         assertSame(expectedText, actualText)

--- a/schema/build.gradle.kts
+++ b/schema/build.gradle.kts
@@ -58,10 +58,10 @@ dependencies {
 }
 
 kotlinter {
-    ignoreFailures = false
+    ignoreLintFailures = false
     reporters = arrayOf("checkstyle", "html")
-    experimentalRules = false
-    fileBatchSize = 30
+//    experimentalRules = false
+//    fileBatchSize = 30
 }
 
 java {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,8 +2,7 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         google()
-        jcenter()
-        maven(url = "https://kotlin.bintray.com/kotlinx")
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
Make the plugin compatible with Gradle 8; prepare for the Gradle 9 support (https://github.com/jmatsu/license-list-plugin/issues/58)
- Bump the Gradle wrapper version to 8.14.2
- Bump the AGP to 8.13.1 to be compatible with Gradle wrapper version
- Bump the Kotlin version to 2.2.21
- Migrate the kotlinx.serialization to 1.9.0 along with the Kotlin version update
  - Now Json is in the separate artifact
  - Serializer changes
    - `.list` extension -> `ListSerializer()`
    - Anonymous class of `SerialDescriptor` -> `buildClassSerialDescriptor` / `PrimitiveSerialDescriptor`
    - `stringify` -> `encodeToString`
    - `parse` -> `decodeFromString`
    - `SerialModule` -> `SerializersModule`
- kotlin-test-junit has gone away for some reason, so migrated to use `kotlin.test` annotations